### PR TITLE
requirements.txt: add cbor2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pycrypto==2.6.1
 pyserial==3.4
 ed25519==1.4
 cbor==1.0.0
+cbor2>=5.0.0
 cryptography==2.6.1
 scapy>=2.4.3
 codespell==1.16.0


### PR DESCRIPTION
`dist/tools/suit/suit-manifest-generator/suit_tool/create.py` requires cbor2 as of https://github.com/RIOT-OS/RIOT/pull/14436.
Install it to being able to build the SUIT update going forward.